### PR TITLE
Manual ack for message consumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions
 of [keepachangelog.com](http://keepachangelog.com/).
 
+## 0.1.2-4 - 2025-02-17 (beta)
+
+### Changed
+
+- Using manual ack for message consumption, so when the message is not processed successfully, it will be re-queued
+  automatically.
+
 ## 0.1.2 - 2025-01-30
 
 ### Fixed

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/rabbitmq-component "0.1.2"
+(defproject net.clojars.macielti/rabbitmq-component "0.1.2-4"
 
   :description "RabbitMQ Integrant Components"
 
@@ -19,7 +19,7 @@
   :profiles {:dev {:test-paths   ^:replace ["test/unit" "test/integration" "test/helpers"]
 
                    :plugins      [[lein-cloverage "1.2.4"]
-                                  [com.github.clojure-lsp/lein-clojure-lsp "1.4.16"]
+                                  [com.github.clojure-lsp/lein-clojure-lsp "1.4.17"]
                                   [com.github.liquidz/antq "RELEASE"]]
 
                    :dependencies [[hashp "0.2.2"]]


### PR DESCRIPTION
### Changed

- Using manual ack for message consumption, so when the message is not processed successfully, it will be re-queued
  automatically.