### PR TITLE
Wrap RabbitMQ connection creation with diehard retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions
 of [keepachangelog.com](http://keepachangelog.com/).
 
+## 0.3.0 - 2026-04-21
+
+### Added
+
+- Wrap RabbitMQ connection creation in producer and consumer components with `diehard` retry (3 attempts, 1–15s backoff) to survive transient broker unavailability at startup.
+
 ## 0.2.3 - 2026-03-06
 
 ### Added

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/rabbitmq "0.2.3"
+(defproject net.clojars.macielti/rabbitmq "0.3.0"
 
   :description "RabbitMQ Integrant Components"
 
@@ -13,6 +13,7 @@
                  [io.pedestal/pedestal.interceptor "0.8.1"]
                  [org.clojure/tools.logging "1.3.1"]
                  [com.novemberain/langohr "5.6.0"]
+                 [diehard "0.12.0"]
                  [net.clojars.macielti/common-clj "46.1.4"]
                  [com.taoensso/nippy "3.6.0"]
                  [org.testcontainers/rabbitmq "1.21.4"]]

--- a/src/rabbitmq/component/consumer.clj
+++ b/src/rabbitmq/component/consumer.clj
@@ -1,5 +1,6 @@
 (ns rabbitmq.component.consumer
   (:require [clojure.tools.logging :as log]
+            [diehard.core :as dh]
             [integrant.core :as ig]
             [io.pedestal.interceptor :as interceptor]
             [io.pedestal.interceptor.chain :as chain]
@@ -57,7 +58,12 @@
         uri (case current-env
               :prod (-> components :config :rabbitmq-uri)
               :test (-> components :rabbitmq-container :url))
-        connection (rmq/connect {:uri uri})
+        connection (dh/with-retry {:max-retries 3
+                                   :backoff-ms  [1000 15000]
+                                   :retry-on    Exception
+                                   :on-retry    (fn [_ _]
+                                                  (log/warn :retrying-rabbitmq-consumer-connection))}
+                     (rmq/connect {:uri uri}))
         channel (lch/open connection)
         consumed-count (when (= current-env :test) (atom 0))]
 

--- a/src/rabbitmq/component/producer.clj
+++ b/src/rabbitmq/component/producer.clj
@@ -1,6 +1,7 @@
 (ns rabbitmq.component.producer
   (:require [clojure.tools.logging :as log]
             [common-clj.traceability.core :as traceability]
+            [diehard.core :as dh]
             [integrant.core :as ig]
             [langohr.basic :as lb]
             [langohr.channel :as lch]
@@ -48,7 +49,12 @@
         uri (case current-env
               :prod (-> components :config :rabbitmq-uri)
               :test (-> components :rabbitmq-container :url))
-        connection (rmq/connect {:uri uri})
+        connection (dh/with-retry {:max-retries 3
+                                   :backoff-ms  [1000 15000]
+                                   :retry-on    Exception
+                                   :on-retry    (fn [_ _]
+                                                  (log/warn :retrying-rabbitmq-producer-connection))}
+                     (rmq/connect {:uri uri}))
         channel (lch/open connection)]
     (misc/assoc-some {:connection  connection
                       :channel     channel


### PR DESCRIPTION
## Summary
- Wrap `rmq/connect` in both producer and consumer components with `diehard.core/with-retry` (3 attempts, 1–15s backoff) so startup survives a broker that isn't quite ready yet.
- Mirrors the pattern already used in the `postgresql` component.
- Bumps version to `0.3.0` and updates CHANGELOG.

## Test plan
- [x] `lein deps` resolves diehard `0.12.0`
- [x] `lein lint`
- [x] `lein test` (unit + integration)
- [x] Smoke: start component without broker → warn logs on retry → start broker mid-retry → component initializes

🤖 Generated with [Claude Code](https://claude.com/claude-code)