### PR TITLE
Bump diehard :max-retries to 5 (0.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions
 of [keepachangelog.com](http://keepachangelog.com/).
 
+## 0.3.1 - 2026-04-21
+
+### Changed
+
+- Increase diehard `:max-retries` from 3 to 5 in producer and consumer connection setup so the exponential backoff actually reaches the configured 15s cap (~30s total retry window instead of ~7s).
+
 ## 0.3.0 - 2026-04-21
 
 ### Added

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/rabbitmq "0.3.0"
+(defproject net.clojars.macielti/rabbitmq "0.3.1"
 
   :description "RabbitMQ Integrant Components"
 

--- a/src/rabbitmq/component/consumer.clj
+++ b/src/rabbitmq/component/consumer.clj
@@ -58,7 +58,7 @@
         uri (case current-env
               :prod (-> components :config :rabbitmq-uri)
               :test (-> components :rabbitmq-container :url))
-        connection (dh/with-retry {:max-retries 3
+        connection (dh/with-retry {:max-retries 5
                                    :backoff-ms  [1000 15000]
                                    :retry-on    Exception
                                    :on-retry    (fn [_ _]

--- a/src/rabbitmq/component/producer.clj
+++ b/src/rabbitmq/component/producer.clj
@@ -49,7 +49,7 @@
         uri (case current-env
               :prod (-> components :config :rabbitmq-uri)
               :test (-> components :rabbitmq-container :url))
-        connection (dh/with-retry {:max-retries 3
+        connection (dh/with-retry {:max-retries 5
                                    :backoff-ms  [1000 15000]
                                    :retry-on    Exception
                                    :on-retry    (fn [_ _]


### PR DESCRIPTION
## Summary

- Bump diehard `:max-retries` from 3 to 5 in producer and consumer connection setup (src/rabbitmq/component/producer.clj:52, src/rabbitmq/component/consumer.clj:61).
- With 5 retries, the exponential backoff sequence (1s → 2s → 4s → 8s → 15s) actually reaches the configured 15s ceiling, extending the connection recovery window from ~7s to ~30s.
- Release `0.3.1` (patch bump — behavior tweak to existing feature, no API change). See `CHANGELOG.md` entry for `0.3.1`.

## Test plan

- [x] `lein lint` passes
- [x] `lein test` integration tests pass